### PR TITLE
Lelantus extra payload support

### DIFF
--- a/contrib/build-wine/deterministic.spec
+++ b/contrib/build-wine/deterministic.spec
@@ -164,6 +164,18 @@ exe = EXE(pyz,
           icon='electrum_firo/gui/icons/electrum-firo.ico',
           name=os.path.join('build\\pyi.win32\\electrum', cmdline_name))
 
+exe_portable = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    name=os.path.join('build\\pyi.win32\\electrum-firo', 'portable-%s' % cmdline_name),
+    debug=False,
+    strip=None,
+    upx=False,
+    icon='electrum_firo/gui/icons/electrum-firo.ico',
+    console=False)
+
 # exe with console output
 conexe = EXE(pyz,
           a.scripts,

--- a/contrib/dash/build.sh
+++ b/contrib/dash/build.sh
@@ -71,6 +71,8 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
         dist/
     cp ${BUILD_DIST_DIR}/${NAME}-${DASH_ELECTRUM_VERSION}-setup-win64.exe \
         dist/
+    cp ${BUILD_DIST_DIR}/portable-electrum-firo-${DASH_ELECTRUM_VERSION}.exe \
+        dist/${NAME}-${DASH_ELECTRUM_VERSION}-portable.exe
 
     # Build deb packages
     PEP440_PUBVER_PATTERN="^((\d+)!)?"

--- a/contrib/dash/travis/travis-build-linux.sh
+++ b/contrib/dash/travis/travis-build-linux.sh
@@ -55,8 +55,8 @@ X11_HASH_FILE=x11_hash-1.4.1-win32.zip
 wget ${X11_HASH_PATH}/${X11_HASH_FILE}
 unzip ${X11_HASH_FILE} && rm ${X11_HASH_FILE}
 
-LSECP256K1_PATH=https://github.com/zebra-lucky/secp256k1/releases/download/0.1
-LSECP256K1_FILE=libsecp256k1-0.1-win32.zip
+LSECP256K1_PATH=https://github.com/zebra-lucky/secp256k1/releases/download/210521
+LSECP256K1_FILE=libsecp256k1-210521-win32.zip
 wget ${LSECP256K1_PATH}/${LSECP256K1_FILE}
 unzip ${LSECP256K1_FILE} && rm ${LSECP256K1_FILE}
 
@@ -86,7 +86,7 @@ X11_HASH_FILE=x11_hash-1.4.1-win64.zip
 wget ${X11_HASH_PATH}/${X11_HASH_FILE}
 unzip ${X11_HASH_FILE} && rm ${X11_HASH_FILE}
 
-LSECP256K1_FILE=libsecp256k1-0.1-win64.zip
+LSECP256K1_FILE=libsecp256k1-210521-win64.zip
 wget ${LSECP256K1_PATH}/${LSECP256K1_FILE}
 unzip ${LSECP256K1_FILE} && rm ${LSECP256K1_FILE}
 

--- a/contrib/dash/travis/travis-build-linux.sh
+++ b/contrib/dash/travis/travis-build-linux.sh
@@ -27,7 +27,6 @@ docker run --rm \
     -w /opt/electrum-dash/contrib/build-linux/appimage \
     -t zebralucky/electrum-dash-winebuild:AppImage40x ./build.sh
 
-
 BUILD_DIR=/root/build
 TOR_PROXY_VERSION=0.4.2.6
 TOR_PROXY_PATH=https://github.com/zebra-lucky/tor-proxy/releases/download

--- a/electrum_dash/dash_tx.py
+++ b/electrum_dash/dash_tx.py
@@ -672,6 +672,25 @@ class DashCbTx(ProTxBase):
             merkleRootQuorums = vds.read_bytes(32)
         return DashCbTx(version, height, merkleRootMNList, merkleRootQuorums)
 
+class FiroLelantusJsplitTx(ProTxBase):
+    __slots__ = ('lelantusData').split()
+
+    def __str__(self):
+        res = ('lelantusData: %s\n'
+               % (self.lelantusData))
+        return res
+
+    def serialize(self):
+        res = (
+            self.lelantusData
+        )
+        return res
+
+    @classmethod
+    def read_vds(cls, vds):
+        tx = FiroLelantusJsplitTx(vds.input[vds.read_cursor:])
+        vds.read_cursor = len(vds.input)
+        return tx
 
 class DashSubTxRegister(ProTxBase):
     '''Class representing DIP5 SubTxRegister'''
@@ -832,10 +851,7 @@ SPEC_PRO_UP_SERV_TX = 2
 SPEC_PRO_UP_REG_TX = 3
 SPEC_PRO_UP_REV_TX = 4
 SPEC_CB_TX = 5
-SPEC_SUB_TX_REGISTER = 8
-SPEC_SUB_TX_TOPUP = 9
-SPEC_SUB_TX_RESET_KEY = 10
-SPEC_SUB_TX_CLOSE_ACCOUNT = 11
+LELANTUS_JSPLIT = 8
 
 
 SPEC_TX_HANDLERS = {
@@ -844,10 +860,7 @@ SPEC_TX_HANDLERS = {
     SPEC_PRO_UP_REG_TX: DashProUpRegTx,
     SPEC_PRO_UP_REV_TX: DashProUpRevTx,
     SPEC_CB_TX: DashCbTx,
-    SPEC_SUB_TX_REGISTER: DashSubTxRegister,
-    SPEC_SUB_TX_TOPUP: DashSubTxTopup,
-    SPEC_SUB_TX_RESET_KEY: DashSubTxResetKey,
-    SPEC_SUB_TX_CLOSE_ACCOUNT: DashSubTxCloseAccount,
+    LELANTUS_JSPLIT: FiroLelantusJsplitTx,
 }
 
 
@@ -871,20 +884,7 @@ SPEC_TX_NAMES = {
     SPEC_PRO_UP_REG_TX: 'ProUpRegTx',
     SPEC_PRO_UP_REV_TX: 'ProUpRevTx',
     SPEC_CB_TX: 'CbTx',
-    SPEC_SUB_TX_REGISTER: 'SubTxRegister',
-    SPEC_SUB_TX_TOPUP: 'SubTxTopup',
-    SPEC_SUB_TX_RESET_KEY: 'SubTxResetKey',
-    SPEC_SUB_TX_CLOSE_ACCOUNT: 'SubTxCloseAccount',
-
-    # as tx_type is uint16, can make PrivateSend types >= 65536
-    PSTxTypes.NEW_DENOMS: 'PS New Denoms',
-    PSTxTypes.NEW_COLLATERAL: 'PS New Collateral',
-    PSTxTypes.DENOMINATE: 'PS Denominate',
-    PSTxTypes.PAY_COLLATERAL: 'PS Pay Collateral',
-    PSTxTypes.PRIVATESEND: 'PrivateSend',
-    PSTxTypes.PS_MIXING_TXS: 'PS Mixing Txs ...',
-    PSTxTypes.SPEND_PS_COINS: 'Spend PS Coins',
-    PSTxTypes.OTHER_PS_COINS: 'Other PS Coins',
+    LELANTUS_JSPLIT: 'LelantusJsplit'
 }
 
 

--- a/electrum_dash/plugins/ledger/ledger.py
+++ b/electrum_dash/plugins/ledger/ledger.py
@@ -135,23 +135,29 @@ class btchip_dash(btchip):
                 self.dongle.exchange(bytearray(apdu))
                 offset += dataLength
 
-        params = []
-        if transaction.extra_data:
-            # Dash DIP2 extra data: By appending data to the 'lockTime' transfer we force the device into the
-            # BTCHIP_TRANSACTION_PROCESS_EXTRA mode, which gives us the opportunity to sneak with an additional
-            # data block.
-            if False and len(transaction.extra_data) > 255 - len(transaction.lockTime):
-                # for now the size should be sufficient
-                raise Exception('The size of the DIP2 extra data block has exceeded the limit.')
-
-            writeVarint(len(transaction.extra_data), params)
-            params.extend(transaction.extra_data)
-
-        apdu = [self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x80, 0x00, len(transaction.lockTime) + len(params)]
-        # Locktime
+        #Sending the lockTime and the extraPayload
+        blockLength = 255
+        buffer = []
+        writeVarint(len(transaction.extra_data), buffer)
+        offset = blockLength - len(transaction.lockTime) - len(buffer)
+        apdu = [self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x80, 0x00, blockLength]
         apdu.extend(transaction.lockTime)
-        apdu.extend(params)
+        apdu.extend(buffer)
+        if offset > len(transaction.extra_data):
+            offset = len(transaction.extra_data)
+        apdu.extend(transaction.extra_data[0: offset])
         response = self.dongle.exchange(bytearray(apdu))
+        while (offset < len(transaction.extra_data)):
+            blockLength = 255
+            if ((offset + blockLength) < len(transaction.extra_data)):
+                dataLength = blockLength
+            else:
+                dataLength = len(transaction.extra_data) - offset
+            apdu = [self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x80, 0x00, dataLength]
+            apdu.extend(transaction.extra_data[offset: offset + dataLength])
+            response = self.dongle.exchange(bytearray(apdu))
+            offset += dataLength
+
         result['trustedInput'] = True
         result['value'] = response
         return result

--- a/electrum_dash/transaction.py
+++ b/electrum_dash/transaction.py
@@ -205,7 +205,8 @@ class TxInput:
         self._is_coinbase_output = is_coinbase_output
 
     def is_lelantus_input(self) -> bool:
-        return self.script_sig and self.script_sig[0] == 199
+        return self.script_sig and \
+               (self.script_sig[0] == 0xC7 or self.script_sig[0] == 0xC9)
 
     def is_coinbase_input(self) -> bool:
         """Whether this is the input of a coinbase tx."""


### PR DESCRIPTION
Add support for Lelantus `vExtrapayload` introduced in [#1063.](https://github.com/firoorg/firo/pull/1063).

Also updated build process and allows for portable Windows binary to be built.