### PR TITLE
Fix testnet coin type

### DIFF
--- a/electrum_dash/constants.py
+++ b/electrum_dash/constants.py
@@ -155,7 +155,7 @@ class BitcoinTestnet(AbstractNet):
     XPUB_HEADERS_INV = inv_dict(XPUB_HEADERS)
     # DRKV_HEADER = 0x3a8061a0  # DRKV
     # DRKP_HEADER = 0x3a805837  # DRKP
-    BIP44_COIN_TYPE = 136
+    BIP44_COIN_TYPE = 1
     COIN = coins.FiroTestnet()
     DIP3_ACTIVATION_HEIGHT = 5000
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `BIP44_COIN_TYPE` for `BitcoinTestnet` to ensure compatibility with external systems and improve testnet functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->