### PR TITLE
Ledger device tx sign fix

### DIFF
--- a/electrum_dash/plugins/ledger/ledger.py
+++ b/electrum_dash/plugins/ledger/ledger.py
@@ -139,10 +139,6 @@ class btchip_dash(btchip):
 
         params = []
         if transaction.extra_data:
-            if len(transaction.extra_data) > 255 - len(transaction.lockTime):
-                # for now the size should be sufficient
-                raise Exception('The size of the DIP2 extra data block has exceeded the limit.')
-
             writeVarint(len(transaction.extra_data), params)
             params.extend(transaction.extra_data)
 

--- a/electrum_dash/plugins/ledger/ledger.py
+++ b/electrum_dash/plugins/ledger/ledger.py
@@ -137,33 +137,23 @@ class btchip_dash(btchip):
                 self.dongle.exchange(bytearray(apdu))
                 offset += dataLength
 
-        #Sending the lockTime and the extraPayload
-        blockLength = 255
-        buffer = []
-        writeVarint(len(transaction.extra_data), buffer)
-        offset = blockLength - len(transaction.lockTime) - len(buffer)
-        apdu = [self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x80, 0x00, blockLength]
-        apdu.extend(transaction.lockTime)
-        apdu.extend(buffer)
-        if offset > len(transaction.extra_data):
-            offset = len(transaction.extra_data)
-        apdu.extend(transaction.extra_data[0: offset])
-        response = self.dongle.exchange(bytearray(apdu))
-        while (offset < len(transaction.extra_data)):
-            blockLength = 255
-            if ((offset + blockLength) < len(transaction.extra_data)):
-                dataLength = blockLength
-            else:
-                dataLength = len(transaction.extra_data) - offset
-            apdu = [self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x80, 0x00, dataLength]
-            apdu.extend(transaction.extra_data[offset: offset + dataLength])
-            response = self.dongle.exchange(bytearray(apdu))
-            offset += dataLength
+        params = []
+        if transaction.extra_data:
+            if len(transaction.extra_data) > 255 - len(transaction.lockTime):
+                # for now the size should be sufficient
+                raise Exception('The size of the DIP2 extra data block has exceeded the limit.')
 
+            writeVarint(len(transaction.extra_data), params)
+            params.extend(transaction.extra_data)
+
+        apdu = [self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x80, 0x00, len(transaction.lockTime) + len(params)]
+        # Locktime
+        apdu.extend(transaction.lockTime)
+        apdu.extend(params)
+        response = self.dongle.exchange(bytearray(apdu))
         result['trustedInput'] = True
         result['value'] = response
         return result
-
 
 class Ledger_Client(HardwareClientBase):
     def __init__(self, hidDevice, *, product_key: Tuple[int, int],
@@ -297,6 +287,7 @@ class Ledger_Client(HardwareClientBase):
                 self.dongleObject.verifyPin(pin)
                 if self.canAlternateCoinVersions:
                     self.dongleObject.setAlternateCoinVersions(constants.net.ADDRTYPE_P2PKH,
+                                                               constants.net.ADDRTYPE_EXP2PKH,
                                                                constants.net.ADDRTYPE_P2SH)
         except BTChipException as e:
             if (e.sw == 0x6faa):
@@ -531,7 +522,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
                     output = txout.address
                     if not self.get_client_electrum().canAlternateCoinVersions:
                         v, h = b58_address_to_hash160(output)
-                        if v == constants.net.ADDRTYPE_P2PKH:
+                        if v == constants.net.ADDRTYPE_P2PKH or v == constants.net.ADDRTYPE_EXP2PKH:
                             output = hash160_to_b58_address(h, 0)
 
         self.handler.show_message(_("Confirm Transaction on your Ledger device..."))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Optimized the `getTrustedInput` method for better handling of `transaction.extra_data`.
  - Enhanced the `perform_hw1_preflight` method to set an additional coin version.
  - Updated the `sign_transaction` method to support an extra address type (`ADDRTYPE_EXP2PKH`).

- **Bug Fixes**
  - Removed exception raise for exceeding DIP2 extra data block size limit in `getTrustedInput`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->