### PR TITLE
Readd portable Electrum for Windows

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -69,6 +69,8 @@ jobs:
           DASH_ELECTRUM_VERSION: ${{ steps.set_vars.outputs.pkg_ver }}
         run: |
           ./contrib/dash/actions/script-wine.sh
+      - name: Rename portable bin
+        run: mv dist/portable-electrum-firo-${{ steps.set_vars.outputs.pkg_ver }}.exe dist/Firo-Electrum-${{ steps.set_vars.outputs.pkg_ver }}-portable.exe
       - name: Upload Artifact
         if: success()
         uses: actions/upload-artifact@v4
@@ -77,6 +79,7 @@ jobs:
           path: |
             dist/Firo-Electrum-${{ steps.set_vars.outputs.pkg_ver }}-setup-win64.exe
             dist/Firo-Electrum-${{ steps.set_vars.outputs.pkg_ver }}-setup-win32.exe
+            dist/Firo-Electrum-${{ steps.set_vars.outputs.pkg_ver }}-portable.exe
 
   build_osx:
     runs-on: macos-12


### PR DESCRIPTION
Portable Electrum was removed when we switched to Github Actions some time ago. This PR reintroduces it so it can be included in our releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved naming convention for the portable executable to enhance clarity and align with branding.
  
- **Chores**
	- Updated artifact upload path to include the newly renamed portable executable, ensuring better accessibility for users after builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->